### PR TITLE
fix ECS migration failing due to file path passed as task definition …

### DIFF
--- a/.github/workflows/elixir_new.yml
+++ b/.github/workflows/elixir_new.yml
@@ -131,10 +131,19 @@ jobs:
           container-name: mehungry_app
           image: ${{ steps.build-image.outputs.image }}
 
+      - name: Register ECS task definition
+        id: register-task-def
+        run: |
+          TASK_DEF_ARN=$(aws ecs register-task-definition \
+            --cli-input-json file://${{ steps.task-def.outputs.task-definition }} \
+            --query "taskDefinition.taskDefinitionArn" \
+            --output text)
+          echo "task-def-arn=$TASK_DEF_ARN" >> $GITHUB_OUTPUT
+
       - name: Run DB migrations
         env:
           ECS_CLUSTER: mehungry_cluster
-          TASK_DEFINITION: "${{ steps.task-def.outputs.task-definition }}"          
+          TASK_DEFINITION: "${{ steps.register-task-def.outputs.task-def-arn }}"
           SUBNETS: subnet-09cf1e07290dd8745,subnet-0e737a54a16cefc1f,subnet-00a18ffb7a73744bf
           SECURITY_GROUP: sg-0a9dca773642f81cf
         run: |
@@ -197,7 +206,7 @@ jobs:
       - name: Deploy Amazon ECS task definition
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
         with:
-          task-definition: ${{ steps.task-def.outputs.task-definition }}
+          task-definition: ${{ steps.register-task-def.outputs.task-def-arn }}
           service: mh-prod-service
           cluster: mehungry_cluster
           wait-for-service-stability: true


### PR DESCRIPTION
…family

Register the task definition explicitly to obtain its ARN, then use that ARN for both run-task (migrations) and the deploy step. Previously the rendered task definition file path was passed directly, which fails the family name regex enforced by the AWS API.