### PR TITLE
Ingredient taxonomies: hierarchical grouping over USDA ingredients

### DIFF
--- a/apps/mehungry/lib/mehungry/ai/taxonomy_classifier.ex
+++ b/apps/mehungry/lib/mehungry/ai/taxonomy_classifier.ex
@@ -1,0 +1,125 @@
+defmodule Mehungry.AI.TaxonomyClassifier do
+  @moduledoc """
+  Classifies USDA ingredient names into the leaf nodes of an ingredient
+  taxonomy. Single-shot JSON prompt over `Mehungry.AI.Client`, mirroring
+  `Mehungry.AI.IngredientTranslator`.
+  """
+
+  @behaviour Mehungry.AI.TaxonomyClassifierBehaviour
+
+  require Logger
+
+  @model "claude-sonnet-4-6"
+  @fallback_slug "other-unclassified"
+
+  @impl true
+  def classify(ingredients, leaves) when is_list(ingredients) and is_list(leaves) do
+    name_to_id = Map.new(ingredients, fn %{id: id, name: name} -> {name, id} end)
+    valid_slugs = MapSet.new(leaves, & &1.slug)
+
+    system = system_prompt(leaves)
+
+    user =
+      "Classify these USDA ingredient names:\n#{Jason.encode!(Map.keys(name_to_id))}"
+
+    case call_api(system, user) do
+      {:ok, text} ->
+        parse_classification_map(text, name_to_id, valid_slugs)
+
+      error ->
+        error
+    end
+  end
+
+  defp system_prompt(leaves) do
+    leaf_lines =
+      Enum.map_join(leaves, "\n", fn %{slug: slug, path: path} -> "- #{slug}: #{path}" end)
+
+    """
+    You are a food scientist classifying ingredients from the USDA food database
+    into a hierarchical food taxonomy.
+
+    The ingredient names use the USDA naming convention: "Primary food, qualifier,
+    qualifier, preparation method, fat trim level...". For example:
+    "Chicken, broilers or fryers, breast, meat only, cooked, roasted" or
+    "Oil, olive, salad or cooking". Identify the CORE ingredient and ignore
+    qualifiers about fat trim, cooking method, and brand specifics.
+
+    These are the available taxonomy leaves, given as "slug: full path":
+    #{leaf_lines}
+
+    Rules:
+    - Assign each ingredient to exactly one leaf slug from the list above.
+    - Choose the most specific leaf that fits the core ingredient.
+    - Composite or prepared dishes belong under the prepared/composite leaves,
+      not under their main ingredient.
+    - If nothing fits, use "#{@fallback_slug}" with a low confidence.
+    - Confidence is a number between 0.0 and 1.0 reflecting how certain you are.
+
+    Return ONLY a valid JSON object mapping each original ingredient name to an
+    object with "leaf" (a slug from the list) and "confidence".
+    No markdown, no explanation, no extra keys.
+
+    Example:
+    {
+      "Beef, ground, 80% lean meat / 20% fat, raw": {"leaf": "beef", "confidence": 0.98},
+      "Fast food, pizza chain, 14\\" pizza": {"leaf": "fast-food", "confidence": 0.9}
+    }
+    """
+  end
+
+  defp parse_classification_map(text, name_to_id, valid_slugs) do
+    cleaned =
+      text
+      |> String.trim()
+      |> String.replace(~r/```json\s*/i, "")
+      |> String.replace(~r/```\s*/, "")
+      |> String.trim()
+
+    case Jason.decode(cleaned) do
+      {:ok, map} when is_map(map) ->
+        result =
+          map
+          |> Enum.flat_map(fn {name, assignment} ->
+            with id when not is_nil(id) <- Map.get(name_to_id, name),
+                 %{"leaf" => slug} <- assignment,
+                 true <- MapSet.member?(valid_slugs, slug) do
+              confidence = normalize_confidence(assignment["confidence"])
+              [{id, %{slug: slug, confidence: confidence}}]
+            else
+              _ ->
+                Logger.warning(
+                  "TaxonomyClassifier: dropping unusable assignment #{inspect(name)} => #{inspect(assignment)}"
+                )
+
+                []
+            end
+          end)
+          |> Map.new()
+
+        {:ok, result}
+
+      _ ->
+        Logger.warning("TaxonomyClassifier: failed to parse response: #{inspect(text)}")
+        {:error, "Could not parse classification response"}
+    end
+  end
+
+  defp normalize_confidence(confidence) when is_number(confidence) do
+    confidence |> max(0.0) |> min(1.0) |> Kernel.*(1.0)
+  end
+
+  defp normalize_confidence(_), do: 0.0
+
+  defp call_api(system, user) do
+    case Mehungry.AI.Client.request(%{
+           model: @model,
+           system: system,
+           messages: [%{role: "user", content: user}],
+           max_tokens: 4096
+         }) do
+      {:ok, response} -> {:ok, Mehungry.AI.Client.text_from(response)}
+      error -> error
+    end
+  end
+end

--- a/apps/mehungry/lib/mehungry/ai/taxonomy_classifier_behaviour.ex
+++ b/apps/mehungry/lib/mehungry/ai/taxonomy_classifier_behaviour.ex
@@ -1,0 +1,17 @@
+defmodule Mehungry.AI.TaxonomyClassifierBehaviour do
+  @moduledoc """
+  Seam for the taxonomy classifier, resolved through the `:taxonomy_classifier`
+  app config key (same pattern as `:social_media_publisher`). Tests wire
+  `Mehungry.AI.TaxonomyClassifierStub` here.
+  """
+
+  @doc """
+  Classifies `ingredients` (`[%{id: integer, name: String.t()}]`) into the
+  taxonomy `leaves` (`[%{id: integer, slug: String.t(), path: String.t()}]`).
+
+  Returns `{:ok, %{ingredient_id => %{slug: String.t(), confidence: float}}}`
+  where every slug is drawn from `leaves`, or `{:error, reason}`.
+  """
+  @callback classify(ingredients :: [map()], leaves :: [map()]) ::
+              {:ok, %{integer() => map()}} | {:error, term()}
+end

--- a/apps/mehungry/lib/mehungry/food.ex
+++ b/apps/mehungry/lib/mehungry/food.ex
@@ -12,6 +12,7 @@ defmodule Mehungry.Food do
     * `Mehungry.Food.Nutrients` — nutrient records and interactions
     * `Mehungry.Food.Measurements` — measurement units and portions
     * `Mehungry.Food.Categories` — categories and food restriction types
+    * `Mehungry.Food.Taxonomies` — hierarchical ingredient taxonomies
     * `Mehungry.Food.Localization` — recipe/ingredient/unit translations
     * `Mehungry.Food.Engagement` — likes, comments, annotations
   """
@@ -24,7 +25,8 @@ defmodule Mehungry.Food do
     Localization,
     Measurements,
     Nutrients,
-    Recipes
+    Recipes,
+    Taxonomies
   }
 
   # ── Recipes ────────────────────────────────────────────────────────────
@@ -139,6 +141,29 @@ defmodule Mehungry.Food do
   defdelegate list_categories(), to: Categories
   defdelegate search_category(term), to: Categories
   defdelegate list_food_restriction_types(), to: Categories
+
+  # ── Taxonomies ─────────────────────────────────────────────────────────
+
+  defdelegate create_taxonomy(attrs), to: Taxonomies
+  defdelegate get_taxonomy!(id), to: Taxonomies
+  defdelegate get_taxonomy_by_slug(slug), to: Taxonomies
+  defdelegate list_taxonomies(), to: Taxonomies
+  defdelegate create_node(attrs), to: Taxonomies
+  defdelegate update_node(node, attrs), to: Taxonomies
+  defdelegate delete_node(node), to: Taxonomies
+  defdelegate get_node!(id), to: Taxonomies
+  defdelegate get_node_by_slug(taxonomy_id, slug), to: Taxonomies
+  defdelegate list_nodes(taxonomy_id), to: Taxonomies
+  defdelegate list_leaf_nodes(taxonomy_id), to: Taxonomies
+  defdelegate list_leaf_paths(taxonomy_id), to: Taxonomies
+  defdelegate build_tree(taxonomy_id), to: Taxonomies
+  defdelegate subtree_node_ids(node_id), to: Taxonomies
+  defdelegate list_ingredients_under_node(node_id), to: Taxonomies
+  defdelegate attach_ingredient(ingredient_id, node_id, attrs \\ %{}), to: Taxonomies
+  defdelegate detach_ingredient(ingredient_id, node_id), to: Taxonomies
+  defdelegate list_pending_review(taxonomy_id, opts \\ []), to: Taxonomies
+  defdelegate count_pending_review(taxonomy_id), to: Taxonomies
+  defdelegate review_mapping(mapping, action), to: Taxonomies
 
   # ── Localization ───────────────────────────────────────────────────────
 

--- a/apps/mehungry/lib/mehungry/food/category.ex
+++ b/apps/mehungry/lib/mehungry/food/category.ex
@@ -10,6 +10,7 @@ defmodule Mehungry.Food.Category do
   schema "categories" do
     field :name, :string
     field :description, :string
+    field :usda_code, :string
 
     has_many :category_translation, CategoryTranslation
     timestamps()
@@ -17,7 +18,7 @@ defmodule Mehungry.Food.Category do
 
   def changeset(category, attrs) do
     category
-    |> cast(attrs, [:name, :description])
+    |> cast(attrs, [:name, :description, :usda_code])
     |> cast_assoc(:category_translation, with: &Mehungry.Food.CategoryTranslation.changeset/2)
     |> validate_required([:name])
     |> unique_constraint(:name)

--- a/apps/mehungry/lib/mehungry/food/ingredient_taxonomy_node.ex
+++ b/apps/mehungry/lib/mehungry/food/ingredient_taxonomy_node.ex
@@ -1,0 +1,32 @@
+defmodule Mehungry.Food.IngredientTaxonomyNode do
+  @moduledoc false
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Mehungry.Food.{Ingredient, TaxonomyNode}
+
+  @sources ~w(usda_seed ai manual)
+
+  schema "ingredient_taxonomy_nodes" do
+    field :source, :string
+    field :confidence, :float
+    field :reviewed, :boolean, default: false
+
+    belongs_to :ingredient, Ingredient
+    belongs_to :taxonomy_node, TaxonomyNode
+
+    timestamps()
+  end
+
+  def changeset(ingredient_taxonomy_node, attrs) do
+    ingredient_taxonomy_node
+    |> cast(attrs, [:source, :confidence, :reviewed, :ingredient_id, :taxonomy_node_id])
+    |> validate_required([:source, :ingredient_id, :taxonomy_node_id])
+    |> validate_inclusion(:source, @sources)
+    |> foreign_key_constraint(:ingredient_id)
+    |> foreign_key_constraint(:taxonomy_node_id)
+    |> unique_constraint([:ingredient_id, :taxonomy_node_id])
+  end
+end

--- a/apps/mehungry/lib/mehungry/food/taxonomies.ex
+++ b/apps/mehungry/lib/mehungry/food/taxonomies.ex
@@ -1,0 +1,288 @@
+defmodule Mehungry.Food.Taxonomies do
+  @moduledoc """
+  Hierarchical ingredient taxonomies.
+
+  A `Taxonomy` is an independent tree of concept nodes (`TaxonomyNode`,
+  adjacency list via `parent_id`) over the shared ingredient pool; ingredients
+  attach to nodes through `IngredientTaxonomyNode` rows that record how the
+  mapping was produced (`usda_seed` | `ai` | `manual`), the classifier's
+  confidence, and whether an admin has reviewed it.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias Mehungry.Repo
+  alias Mehungry.Food.{Ingredient, IngredientTaxonomyNode, Taxonomy, TaxonomyNode}
+
+  # ── Taxonomies ─────────────────────────────────────────────────────────
+
+  def create_taxonomy(attrs) do
+    %Taxonomy{}
+    |> Taxonomy.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def get_taxonomy!(id), do: Repo.get!(Taxonomy, id)
+
+  def get_taxonomy_by_slug(slug), do: Repo.get_by(Taxonomy, slug: slug)
+
+  def list_taxonomies, do: Repo.all(Taxonomy)
+
+  # ── Nodes ──────────────────────────────────────────────────────────────
+
+  def create_node(attrs) do
+    %TaxonomyNode{}
+    |> TaxonomyNode.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def update_node(%TaxonomyNode{} = node, attrs) do
+    node
+    |> TaxonomyNode.changeset(attrs)
+    |> Repo.update()
+  end
+
+  def delete_node(%TaxonomyNode{} = node), do: Repo.delete(node)
+
+  def get_node!(id), do: Repo.get!(TaxonomyNode, id)
+
+  def get_node_by_slug(taxonomy_id, slug) do
+    Repo.get_by(TaxonomyNode, taxonomy_id: taxonomy_id, slug: slug)
+  end
+
+  def list_nodes(taxonomy_id) do
+    from(n in TaxonomyNode,
+      where: n.taxonomy_id == ^taxonomy_id,
+      order_by: [asc: n.position, asc: n.name]
+    )
+    |> Repo.all()
+  end
+
+  @doc """
+  Nodes of the taxonomy that have no children — the attachment targets the AI
+  classifier and the review override select choose from.
+  """
+  def list_leaf_nodes(taxonomy_id) do
+    from(n in TaxonomyNode,
+      left_join: c in TaxonomyNode,
+      on: c.parent_id == n.id,
+      where: n.taxonomy_id == ^taxonomy_id and is_nil(c.id),
+      order_by: [asc: n.position, asc: n.name]
+    )
+    |> Repo.all()
+  end
+
+  @doc """
+  Leaf nodes annotated with their ancestor path, e.g.
+  `%{id: 12, slug: "beef", path: "Meat > Red Meat > Beef"}`.
+  """
+  def list_leaf_paths(taxonomy_id) do
+    nodes = list_nodes(taxonomy_id)
+    by_id = Map.new(nodes, &{&1.id, &1})
+    children_of = Enum.group_by(nodes, & &1.parent_id)
+
+    nodes
+    |> Enum.reject(fn n -> Map.has_key?(children_of, n.id) end)
+    |> Enum.map(fn leaf ->
+      %{id: leaf.id, slug: leaf.slug, path: build_path(leaf, by_id)}
+    end)
+  end
+
+  defp build_path(node, by_id, acc \\ [])
+
+  defp build_path(%TaxonomyNode{parent_id: nil} = node, _by_id, acc) do
+    Enum.join([node.name | acc], " > ")
+  end
+
+  defp build_path(%TaxonomyNode{} = node, by_id, acc) do
+    build_path(Map.fetch!(by_id, node.parent_id), by_id, [node.name | acc])
+  end
+
+  # ── Tree assembly ──────────────────────────────────────────────────────
+
+  @doc """
+  Assembles the taxonomy's persisted nodes into nested
+  `%{id, name, slug, amount, measurement_unit, children}` maps — the shape
+  `MehungryWeb.AccordionComponent` consumes. `amount` carries the rolled-up
+  count of ingredients attached anywhere in the node's subtree.
+  """
+  def build_tree(taxonomy_id) do
+    nodes = list_nodes(taxonomy_id)
+    children_of = Enum.group_by(nodes, & &1.parent_id)
+
+    counts =
+      from(itn in IngredientTaxonomyNode,
+        join: n in TaxonomyNode,
+        on: n.id == itn.taxonomy_node_id,
+        where: n.taxonomy_id == ^taxonomy_id,
+        group_by: itn.taxonomy_node_id,
+        select: {itn.taxonomy_node_id, count(itn.id)}
+      )
+      |> Repo.all()
+      |> Map.new()
+
+    children_of
+    |> Map.get(nil, [])
+    |> Enum.map(&build_tree_node(&1, children_of, counts))
+  end
+
+  defp build_tree_node(node, children_of, counts) do
+    children =
+      children_of
+      |> Map.get(node.id, [])
+      |> Enum.map(&build_tree_node(&1, children_of, counts))
+
+    rolled_up_count =
+      Map.get(counts, node.id, 0) + (children |> Enum.map(& &1.amount) |> Enum.sum())
+
+    %{
+      id: node.id,
+      name: node.name,
+      slug: node.slug,
+      amount: rolled_up_count,
+      measurement_unit: "foods",
+      children: children
+    }
+  end
+
+  # ── Subtree queries ────────────────────────────────────────────────────
+
+  @doc """
+  Ids of the node and all of its descendants, via a recursive CTE over
+  `taxonomy_nodes.parent_id`.
+  """
+  def subtree_node_ids(node_id) do
+    Repo.all(subtree_query(node_id))
+  end
+
+  defp subtree_query(node_id) do
+    base = from(n in TaxonomyNode, where: n.id == ^node_id, select: n.id)
+
+    recursion =
+      from(n in TaxonomyNode,
+        join: s in "subtree",
+        on: n.parent_id == s.id,
+        select: n.id
+      )
+
+    cte = union_all(base, ^recursion)
+
+    from(s in "subtree", select: s.id)
+    |> recursive_ctes(true)
+    |> with_cte("subtree", as: ^cte)
+  end
+
+  @doc """
+  Ingredients attached to the node or any of its descendants.
+  """
+  def list_ingredients_under_node(node_id) do
+    from(i in Ingredient,
+      join: itn in IngredientTaxonomyNode,
+      on: itn.ingredient_id == i.id,
+      where: itn.taxonomy_node_id in subquery(subtree_query(node_id)),
+      distinct: i.id,
+      order_by: [asc: i.name]
+    )
+    |> Repo.all()
+  end
+
+  # ── Ingredient attachment ──────────────────────────────────────────────
+
+  def attach_ingredient(ingredient_id, taxonomy_node_id, attrs \\ %{}) do
+    attrs =
+      attrs
+      |> Map.new(fn {k, v} -> {to_string(k), v} end)
+      |> Map.merge(%{
+        "ingredient_id" => ingredient_id,
+        "taxonomy_node_id" => taxonomy_node_id
+      })
+      |> Map.put_new("source", "manual")
+
+    %IngredientTaxonomyNode{}
+    |> IngredientTaxonomyNode.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def detach_ingredient(ingredient_id, taxonomy_node_id) do
+    from(itn in IngredientTaxonomyNode,
+      where: itn.ingredient_id == ^ingredient_id and itn.taxonomy_node_id == ^taxonomy_node_id
+    )
+    |> Repo.delete_all()
+  end
+
+  @doc """
+  Ids of ingredients that have no mapping in the given taxonomy — the AI
+  classifier's work queue.
+  """
+  def unclassified_ingredients_query(taxonomy_id) do
+    classified =
+      from(itn in IngredientTaxonomyNode,
+        join: n in TaxonomyNode,
+        on: n.id == itn.taxonomy_node_id,
+        where: n.taxonomy_id == ^taxonomy_id,
+        select: itn.ingredient_id
+      )
+
+    from(i in Ingredient, where: i.id not in subquery(classified))
+  end
+
+  # ── Review ─────────────────────────────────────────────────────────────
+
+  @doc """
+  Unreviewed mappings for the taxonomy, lowest confidence first (nulls first),
+  with ingredient and node preloaded. Options: `:limit` (default 50),
+  `:offset` (default 0).
+  """
+  def list_pending_review(taxonomy_id, opts \\ []) do
+    limit = Keyword.get(opts, :limit, 50)
+    offset = Keyword.get(opts, :offset, 0)
+
+    from(itn in IngredientTaxonomyNode,
+      join: n in TaxonomyNode,
+      on: n.id == itn.taxonomy_node_id,
+      where: n.taxonomy_id == ^taxonomy_id and itn.reviewed == false,
+      order_by: [asc_nulls_first: itn.confidence, asc: itn.id],
+      limit: ^limit,
+      offset: ^offset,
+      preload: [ingredient: :category, taxonomy_node: :parent]
+    )
+    |> Repo.all()
+  end
+
+  def count_pending_review(taxonomy_id) do
+    from(itn in IngredientTaxonomyNode,
+      join: n in TaxonomyNode,
+      on: n.id == itn.taxonomy_node_id,
+      where: n.taxonomy_id == ^taxonomy_id and itn.reviewed == false,
+      select: count(itn.id)
+    )
+    |> Repo.one()
+  end
+
+  @doc """
+  Resolves a pending mapping: `:confirm` keeps the assigned node, while
+  `{:override, node_id}` moves it to the given node as a manual assignment.
+  """
+  def review_mapping(%IngredientTaxonomyNode{} = mapping, :confirm) do
+    mapping
+    |> IngredientTaxonomyNode.changeset(%{reviewed: true})
+    |> Repo.update()
+  end
+
+  def review_mapping(%IngredientTaxonomyNode{} = mapping, {:override, taxonomy_node_id}) do
+    mapping
+    |> IngredientTaxonomyNode.changeset(%{
+      taxonomy_node_id: taxonomy_node_id,
+      source: "manual",
+      confidence: nil,
+      reviewed: true
+    })
+    |> Repo.update()
+  end
+
+  def review_mapping(mapping_id, action) when is_integer(mapping_id) do
+    IngredientTaxonomyNode
+    |> Repo.get!(mapping_id)
+    |> review_mapping(action)
+  end
+end

--- a/apps/mehungry/lib/mehungry/food/taxonomy.ex
+++ b/apps/mehungry/lib/mehungry/food/taxonomy.ex
@@ -1,0 +1,26 @@
+defmodule Mehungry.Food.Taxonomy do
+  @moduledoc false
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Mehungry.Food.TaxonomyNode
+
+  schema "taxonomies" do
+    field :name, :string
+    field :slug, :string
+    field :description, :string
+
+    has_many :nodes, TaxonomyNode
+
+    timestamps()
+  end
+
+  def changeset(taxonomy, attrs) do
+    taxonomy
+    |> cast(attrs, [:name, :slug, :description])
+    |> validate_required([:name, :slug])
+    |> unique_constraint(:slug)
+  end
+end

--- a/apps/mehungry/lib/mehungry/food/taxonomy_node.ex
+++ b/apps/mehungry/lib/mehungry/food/taxonomy_node.ex
@@ -1,0 +1,31 @@
+defmodule Mehungry.Food.TaxonomyNode do
+  @moduledoc false
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Mehungry.Food.{IngredientTaxonomyNode, Taxonomy, TaxonomyNode}
+
+  schema "taxonomy_nodes" do
+    field :name, :string
+    field :slug, :string
+    field :position, :integer, default: 0
+
+    belongs_to :taxonomy, Taxonomy
+    belongs_to :parent, TaxonomyNode
+    has_many :children, TaxonomyNode, foreign_key: :parent_id
+    has_many :ingredient_taxonomy_nodes, IngredientTaxonomyNode
+
+    timestamps()
+  end
+
+  def changeset(taxonomy_node, attrs) do
+    taxonomy_node
+    |> cast(attrs, [:name, :slug, :position, :taxonomy_id, :parent_id])
+    |> validate_required([:name, :slug, :taxonomy_id])
+    |> foreign_key_constraint(:taxonomy_id)
+    |> foreign_key_constraint(:parent_id)
+    |> unique_constraint([:taxonomy_id, :slug])
+  end
+end

--- a/apps/mehungry/lib/mehungry/food/taxonomy_seeder.ex
+++ b/apps/mehungry/lib/mehungry/food/taxonomy_seeder.ex
@@ -1,0 +1,162 @@
+defmodule Mehungry.Food.TaxonomySeeder do
+  @moduledoc """
+  Seeds the first ingredient taxonomy: "Biological / Nutritional".
+
+  The tree is curated by hand — USDA food-group codes are too coarse to give
+  levels like "Red Meat". Seeding is idempotent: taxonomies and nodes are
+  looked up by slug and only created when missing, so the task can be re-run
+  after adding nodes to `@tree`.
+
+  The "Other / Unclassified" leaf is load-bearing: the AI classifier uses it
+  as the fallback assignment, which guarantees every ingredient eventually
+  gets a mapping and the classification worker terminates.
+  """
+
+  alias Mehungry.Food.Taxonomies
+
+  @taxonomy %{
+    name: "Biological / Nutritional",
+    slug: "bio-nutritional",
+    description:
+      "Groups ingredients by what they are biologically and nutritionally, " <>
+        "e.g. Meat > Red Meat > Beef."
+  }
+
+  # {name, children} — slugs are derived from names.
+  @tree [
+    {"Meat",
+     [
+       {"Red Meat", [{"Beef", []}, {"Lamb", []}, {"Pork", []}, {"Goat", []}, {"Veal", []}]},
+       {"Poultry", [{"Chicken", []}, {"Turkey", []}, {"Duck", []}, {"Other Poultry", []}]},
+       {"Game Meat", []},
+       {"Organ Meat", []},
+       {"Processed Meat", []}
+     ]},
+    {"Fish & Seafood",
+     [
+       {"Fatty Fish", []},
+       {"Lean Fish", []},
+       {"Crustaceans", []},
+       {"Mollusks", []},
+       {"Other Seafood", []}
+     ]},
+    {"Dairy & Eggs",
+     [
+       {"Milk", []},
+       {"Yogurt & Fermented Dairy", []},
+       {"Cheese", []},
+       {"Cream & Butter", []},
+       {"Eggs", []}
+     ]},
+    {"Vegetables",
+     [
+       {"Leafy Greens", []},
+       {"Cruciferous Vegetables", []},
+       {"Root Vegetables", []},
+       {"Nightshades", []},
+       {"Alliums", []},
+       {"Squashes & Gourds", []},
+       {"Stalks & Shoots", []},
+       {"Mushrooms", []},
+       {"Sea Vegetables", []},
+       {"Other Vegetables", []}
+     ]},
+    {"Fruits",
+     [
+       {"Berries", []},
+       {"Citrus Fruits", []},
+       {"Stone Fruits", []},
+       {"Pome Fruits", []},
+       {"Tropical Fruits", []},
+       {"Melons", []},
+       {"Dried Fruits", []},
+       {"Other Fruits", []}
+     ]},
+    {"Grains & Cereals",
+     [
+       {"Whole Grains", []},
+       {"Refined Grains", []},
+       {"Breads & Baked Grains", []},
+       {"Pasta & Noodles", []},
+       {"Breakfast Cereals", []}
+     ]},
+    {"Legumes",
+     [{"Beans", []}, {"Lentils", []}, {"Peas", []}, {"Soy Products", []}, {"Peanuts", []}]},
+    {"Nuts & Seeds", [{"Tree Nuts", []}, {"Seeds", []}, {"Nut & Seed Butters", []}]},
+    {"Fats & Oils", [{"Plant Oils", []}, {"Animal Fats", []}]},
+    {"Herbs & Spices", [{"Fresh Herbs", []}, {"Dried Herbs & Spices", []}, {"Salt & Blends", []}]},
+    {"Sweeteners", [{"Sugars & Syrups", []}, {"Honey", []}, {"Sugar Substitutes", []}]},
+    {"Condiments & Sauces", []},
+    {"Beverages",
+     [
+       {"Water", []},
+       {"Juices", []},
+       {"Coffee & Tea", []},
+       {"Soft Drinks", []},
+       {"Alcoholic Beverages", []},
+       {"Plant Milks", []}
+     ]},
+    {"Sweets & Snacks",
+     [{"Chocolate & Confectionery", []}, {"Baked Sweets", []}, {"Savory Snacks", []}]},
+    {"Prepared & Composite Foods",
+     [{"Soups & Stews", []}, {"Fast Food", []}, {"Ready Meals", []}, {"Baby Food", []}]},
+    {"Supplements & Additives", []},
+    {"Other / Unclassified", []}
+  ]
+
+  @doc """
+  Idempotently creates the Biological/Nutritional taxonomy and its node tree.
+  Returns the taxonomy.
+  """
+  def seed do
+    taxonomy =
+      case Taxonomies.get_taxonomy_by_slug(@taxonomy.slug) do
+        nil ->
+          {:ok, taxonomy} = Taxonomies.create_taxonomy(@taxonomy)
+          taxonomy
+
+        taxonomy ->
+          taxonomy
+      end
+
+    seed_nodes(taxonomy, @tree, nil)
+    taxonomy
+  end
+
+  defp seed_nodes(taxonomy, children, parent_id) do
+    children
+    |> Enum.with_index()
+    |> Enum.each(fn {{name, grandchildren}, position} ->
+      node = get_or_create_node(taxonomy, name, parent_id, position)
+      seed_nodes(taxonomy, grandchildren, node.id)
+    end)
+  end
+
+  defp get_or_create_node(taxonomy, name, parent_id, position) do
+    slug = slugify(name)
+
+    case Taxonomies.get_node_by_slug(taxonomy.id, slug) do
+      nil ->
+        {:ok, node} =
+          Taxonomies.create_node(%{
+            taxonomy_id: taxonomy.id,
+            parent_id: parent_id,
+            name: name,
+            slug: slug,
+            position: position
+          })
+
+        node
+
+      node ->
+        node
+    end
+  end
+
+  def slugify(name) do
+    name
+    |> String.downcase()
+    |> String.replace(~r/[^a-z0-9]+/, "-")
+    |> String.trim("-")
+  end
+end

--- a/apps/mehungry/lib/mehungry/food_data/usda/food_parser.ex
+++ b/apps/mehungry/lib/mehungry/food_data/usda/food_parser.ex
@@ -142,7 +142,13 @@ defmodule Mehungry.FoodData.Usda.FoodParser do
           description
       end
 
-    category = get_or_create_food_category(attrs_description)
+    usda_code =
+      case attrs["foodCategory"]["code"] || attrs["wweiaFoodCategory"]["wweiaFoodCategoryCode"] do
+        nil -> nil
+        code -> to_string(code)
+      end
+
+    category = get_or_create_food_category(attrs_description, usda_code)
 
     category_id =
       case is_nil(category) do
@@ -197,16 +203,20 @@ defmodule Mehungry.FoodData.Usda.FoodParser do
     end
   end
 
-  defp get_or_create_food_category(nil), do: nil
+  defp get_or_create_food_category(nil, _usda_code), do: nil
 
-  defp get_or_create_food_category(category_name) do
-    category = Food.get_category_by_name(category_name)
+  defp get_or_create_food_category(category_name, usda_code) do
+    case Food.get_category_by_name(category_name) do
+      nil ->
+        {:ok, category} = Food.create_category(%{name: category_name, usda_code: usda_code})
+        category
 
-    if is_nil(category) do
-      {:ok, category} = Food.create_category(%{name: category_name})
-      category
-    else
-      category
+      %{usda_code: nil} = category when not is_nil(usda_code) ->
+        {:ok, category} = Food.update_category(category, %{usda_code: usda_code})
+        category
+
+      category ->
+        category
     end
   end
 

--- a/apps/mehungry/lib/mehungry/oban_workers/taxonomy_classification_worker.ex
+++ b/apps/mehungry/lib/mehungry/oban_workers/taxonomy_classification_worker.ex
@@ -1,0 +1,126 @@
+defmodule Mehungry.ObanWorkers.TaxonomyClassificationWorker do
+  @moduledoc """
+  Classifies ingredients into a taxonomy's leaf nodes in batches, re-enqueueing
+  itself until every ingredient has a mapping (mirrors
+  `Mehungry.IngredientTranslationWorker`).
+
+  Termination is guaranteed by two mechanisms: the seeded "Other / Unclassified"
+  fallback leaf means the AI can always place an ingredient somewhere, and a
+  batch that produces zero inserts stops the chain instead of re-enqueueing.
+  """
+
+  use Oban.Worker, queue: :ai_agents, max_attempts: 3
+
+  require Logger
+
+  import Ecto.Query
+
+  alias Mehungry.Food.{IngredientTaxonomyNode, Taxonomies}
+  alias Mehungry.Repo
+
+  @batch_size 40
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"taxonomy_id" => taxonomy_id}}) do
+    batch = fetch_unclassified_batch(taxonomy_id)
+
+    case batch do
+      [] ->
+        Logger.info(
+          "[TaxonomyClassificationWorker] all ingredients classified for taxonomy #{taxonomy_id}"
+        )
+
+        :ok
+
+      ingredients ->
+        leaves = Taxonomies.list_leaf_paths(taxonomy_id)
+
+        Logger.info(
+          "[TaxonomyClassificationWorker] classifying batch of #{length(ingredients)} " <>
+            "into #{length(leaves)} leaves (taxonomy #{taxonomy_id})"
+        )
+
+        case classifier().classify(ingredients, leaves) do
+          {:ok, assignments} ->
+            handle_assignments(taxonomy_id, assignments, leaves)
+
+          {:error, reason} ->
+            Logger.warning(
+              "[TaxonomyClassificationWorker] classification failed: #{inspect(reason)}"
+            )
+
+            {:error, reason}
+        end
+    end
+  end
+
+  def enqueue(taxonomy_id) do
+    %{taxonomy_id: taxonomy_id}
+    |> new()
+    |> Oban.insert()
+  end
+
+  defp handle_assignments(taxonomy_id, assignments, leaves) do
+    slug_to_node_id = Map.new(leaves, fn %{slug: slug, id: id} -> {slug, id} end)
+    inserted = insert_assignments(assignments, slug_to_node_id)
+
+    if inserted > 0 do
+      Logger.info("[TaxonomyClassificationWorker] inserted #{inserted} mappings")
+      enqueue(taxonomy_id)
+      :ok
+    else
+      Logger.warning(
+        "[TaxonomyClassificationWorker] batch produced no usable assignments, " <>
+          "stopping to avoid a retry loop (taxonomy #{taxonomy_id})"
+      )
+
+      :ok
+    end
+  end
+
+  defp fetch_unclassified_batch(taxonomy_id) do
+    taxonomy_id
+    |> Taxonomies.unclassified_ingredients_query()
+    |> order_by([i], asc: i.id)
+    |> limit(@batch_size)
+    |> select([i], %{id: i.id, name: i.name})
+    |> Repo.all()
+  end
+
+  defp insert_assignments(assignments, slug_to_node_id) do
+    now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+
+    rows =
+      Enum.flat_map(assignments, fn {ingredient_id, %{slug: slug, confidence: confidence}} ->
+        case Map.get(slug_to_node_id, slug) do
+          nil ->
+            []
+
+          node_id ->
+            [
+              %{
+                ingredient_id: ingredient_id,
+                taxonomy_node_id: node_id,
+                source: "ai",
+                confidence: confidence,
+                reviewed: false,
+                inserted_at: now,
+                updated_at: now
+              }
+            ]
+        end
+      end)
+
+    {count, _} =
+      Repo.insert_all(IngredientTaxonomyNode, rows,
+        on_conflict: :nothing,
+        conflict_target: [:ingredient_id, :taxonomy_node_id]
+      )
+
+    count
+  end
+
+  defp classifier do
+    Application.get_env(:mehungry, :taxonomy_classifier, Mehungry.AI.TaxonomyClassifier)
+  end
+end

--- a/apps/mehungry/lib/mix/tasks/taxonomy_classify.ex
+++ b/apps/mehungry/lib/mix/tasks/taxonomy_classify.ex
@@ -1,0 +1,19 @@
+defmodule Mix.Tasks.Taxonomy.Classify do
+  @shortdoc "Enqueues Oban jobs to AI-classify ingredients into the bio-nutritional taxonomy"
+
+  use Mix.Task
+
+  @requirements ["app.start"]
+
+  @impl Mix.Task
+  def run(_args) do
+    case Mehungry.Food.Taxonomies.get_taxonomy_by_slug("bio-nutritional") do
+      nil ->
+        Mix.raise("Taxonomy 'bio-nutritional' not found. Run `mix taxonomy.seed` first.")
+
+      taxonomy ->
+        {:ok, _job} = Mehungry.ObanWorkers.TaxonomyClassificationWorker.enqueue(taxonomy.id)
+        Mix.shell().info("Taxonomy classification job enqueued. Check Oban for progress.")
+    end
+  end
+end

--- a/apps/mehungry/lib/mix/tasks/taxonomy_seed.ex
+++ b/apps/mehungry/lib/mix/tasks/taxonomy_seed.ex
@@ -1,0 +1,14 @@
+defmodule Mix.Tasks.Taxonomy.Seed do
+  @shortdoc "Seeds the Biological/Nutritional ingredient taxonomy node tree"
+
+  use Mix.Task
+
+  @requirements ["app.start"]
+
+  @impl Mix.Task
+  def run(_args) do
+    taxonomy = Mehungry.Food.TaxonomySeeder.seed()
+    node_count = length(Mehungry.Food.Taxonomies.list_nodes(taxonomy.id))
+    Mix.shell().info("Taxonomy '#{taxonomy.slug}' seeded with #{node_count} nodes.")
+  end
+end

--- a/apps/mehungry/priv/repo/migrations/20260723120000_create_taxonomies.exs
+++ b/apps/mehungry/priv/repo/migrations/20260723120000_create_taxonomies.exs
@@ -1,0 +1,58 @@
+defmodule Mehungry.Repo.Migrations.CreateTaxonomies do
+  use Ecto.Migration
+
+  def up do
+    create table(:taxonomies) do
+      add :name, :string, null: false
+      add :slug, :string, null: false
+      add :description, :text
+
+      timestamps()
+    end
+
+    create unique_index(:taxonomies, [:slug])
+
+    create table(:taxonomy_nodes) do
+      add :taxonomy_id, references(:taxonomies, on_delete: :delete_all), null: false
+      add :parent_id, references(:taxonomy_nodes, on_delete: :delete_all)
+      add :name, :string, null: false
+      add :slug, :string, null: false
+      add :position, :integer, default: 0, null: false
+
+      timestamps()
+    end
+
+    # UNIQUE(taxonomy_id, parent_id, slug) would not catch duplicate roots on
+    # PG14 (NULL parent_id rows are never equal), so slugs are unique per taxonomy.
+    create unique_index(:taxonomy_nodes, [:taxonomy_id, :slug])
+    create index(:taxonomy_nodes, [:parent_id])
+
+    create table(:ingredient_taxonomy_nodes) do
+      add :ingredient_id, references(:ingredients, on_delete: :delete_all), null: false
+      add :taxonomy_node_id, references(:taxonomy_nodes, on_delete: :delete_all), null: false
+      add :source, :string, null: false
+      add :confidence, :float
+      add :reviewed, :boolean, default: false, null: false
+
+      timestamps()
+    end
+
+    create unique_index(:ingredient_taxonomy_nodes, [:ingredient_id, :taxonomy_node_id])
+    create index(:ingredient_taxonomy_nodes, [:taxonomy_node_id])
+    create index(:ingredient_taxonomy_nodes, [:reviewed, :confidence])
+
+    alter table(:categories) do
+      add :usda_code, :string
+    end
+  end
+
+  def down do
+    alter table(:categories) do
+      remove :usda_code
+    end
+
+    drop table(:ingredient_taxonomy_nodes)
+    drop table(:taxonomy_nodes)
+    drop table(:taxonomies)
+  end
+end

--- a/apps/mehungry/priv/repo/seeds.exs
+++ b/apps/mehungry/priv/repo/seeds.exs
@@ -18,6 +18,8 @@ require Logger
 {:ok, fr} = Mehungry.Repo.insert(%Mehungry.Food.FoodRestrictionType{title: "Fun"})
 {:ok, fr} = Mehungry.Repo.insert(%Mehungry.Food.FoodRestrictionType{title: "Absolutely fun"})
 
+Mehungry.Food.TaxonomySeeder.seed()
+
 """
 {:ok, gram} = Mehungry.Repo.insert(%Mehungry.Food.MeasurementUnit{name: "gram"})
 {:ok, kg} = Mehungry.Repo.insert(%Mehungry.Food.MeasurementUnit{name: "kg"})

--- a/apps/mehungry/test/mehungry/food/taxonomies_test.exs
+++ b/apps/mehungry/test/mehungry/food/taxonomies_test.exs
@@ -1,0 +1,193 @@
+defmodule Mehungry.Food.TaxonomiesTest do
+  use Mehungry.DataCase
+
+  alias Mehungry.Food.Taxonomies
+  alias Mehungry.FoodFixtures
+
+  defp taxonomy_fixture do
+    {:ok, taxonomy} =
+      Taxonomies.create_taxonomy(%{name: "Biological / Nutritional", slug: "bio-nutritional"})
+
+    taxonomy
+  end
+
+  defp node_fixture(taxonomy, attrs) do
+    {:ok, node} =
+      attrs
+      |> Map.put(:taxonomy_id, taxonomy.id)
+      |> Taxonomies.create_node()
+
+    node
+  end
+
+  # Food > Meat > Red Meat > {Beef, Lamb}
+  #             > Poultry  > {Chicken}
+  defp seed_meat_tree(taxonomy) do
+    food = node_fixture(taxonomy, %{name: "Food", slug: "food"})
+    meat = node_fixture(taxonomy, %{name: "Meat", slug: "meat", parent_id: food.id})
+    red_meat = node_fixture(taxonomy, %{name: "Red Meat", slug: "red-meat", parent_id: meat.id})
+    poultry = node_fixture(taxonomy, %{name: "Poultry", slug: "poultry", parent_id: meat.id})
+    beef = node_fixture(taxonomy, %{name: "Beef", slug: "beef", parent_id: red_meat.id})
+    lamb = node_fixture(taxonomy, %{name: "Lamb", slug: "lamb", parent_id: red_meat.id})
+    chicken = node_fixture(taxonomy, %{name: "Chicken", slug: "chicken", parent_id: poultry.id})
+
+    %{
+      food: food,
+      meat: meat,
+      red_meat: red_meat,
+      poultry: poultry,
+      beef: beef,
+      lamb: lamb,
+      chicken: chicken
+    }
+  end
+
+  describe "node constraints" do
+    test "duplicate slug within a taxonomy is rejected, including for two roots" do
+      taxonomy = taxonomy_fixture()
+      node_fixture(taxonomy, %{name: "Meat", slug: "meat"})
+
+      assert {:error, changeset} =
+               Taxonomies.create_node(%{name: "Meat 2", slug: "meat", taxonomy_id: taxonomy.id})
+
+      assert %{taxonomy_id: ["has already been taken"]} = errors_on(changeset)
+    end
+
+    test "the same slug is allowed across taxonomies" do
+      taxonomy = taxonomy_fixture()
+      {:ok, other} = Taxonomies.create_taxonomy(%{name: "Culinary", slug: "culinary"})
+
+      node_fixture(taxonomy, %{name: "Meat", slug: "meat"})
+      assert {:ok, _} = Taxonomies.create_node(%{name: "Meat", slug: "meat", taxonomy_id: other.id})
+    end
+  end
+
+  describe "subtree queries" do
+    test "list_ingredients_under_node/1 traverses the full subtree" do
+      taxonomy = taxonomy_fixture()
+      nodes = seed_meat_tree(taxonomy)
+
+      beef_ing = FoodFixtures.ingredient_fixture(%{name: "Beef, ground, raw"})
+      lamb_ing = FoodFixtures.ingredient_fixture(%{name: "Lamb, leg, raw"})
+      chicken_ing = FoodFixtures.ingredient_fixture(%{name: "Chicken, breast, raw"})
+
+      {:ok, _} = Taxonomies.attach_ingredient(beef_ing.id, nodes.beef.id, %{source: "manual"})
+      {:ok, _} = Taxonomies.attach_ingredient(lamb_ing.id, nodes.lamb.id, %{source: "manual"})
+
+      {:ok, _} =
+        Taxonomies.attach_ingredient(chicken_ing.id, nodes.chicken.id, %{source: "manual"})
+
+      red_meat_ids = Taxonomies.list_ingredients_under_node(nodes.red_meat.id) |> ids()
+      assert red_meat_ids == Enum.sort([beef_ing.id, lamb_ing.id])
+
+      meat_ids = Taxonomies.list_ingredients_under_node(nodes.meat.id) |> ids()
+      assert meat_ids == Enum.sort([beef_ing.id, lamb_ing.id, chicken_ing.id])
+
+      poultry_ids = Taxonomies.list_ingredients_under_node(nodes.poultry.id) |> ids()
+      assert poultry_ids == [chicken_ing.id]
+    end
+
+    test "subtree_node_ids/1 includes the node itself and all descendants" do
+      taxonomy = taxonomy_fixture()
+      nodes = seed_meat_tree(taxonomy)
+
+      assert Enum.sort(Taxonomies.subtree_node_ids(nodes.red_meat.id)) ==
+               Enum.sort([nodes.red_meat.id, nodes.beef.id, nodes.lamb.id])
+
+      assert Taxonomies.subtree_node_ids(nodes.chicken.id) == [nodes.chicken.id]
+    end
+  end
+
+  describe "build_tree/1" do
+    test "returns nested maps with rolled-up counts in the accordion shape" do
+      taxonomy = taxonomy_fixture()
+      nodes = seed_meat_tree(taxonomy)
+
+      beef_ing = FoodFixtures.ingredient_fixture(%{name: "Beef, chuck, raw"})
+      chicken_ing = FoodFixtures.ingredient_fixture(%{name: "Chicken, thigh, raw"})
+
+      {:ok, _} = Taxonomies.attach_ingredient(beef_ing.id, nodes.beef.id, %{source: "manual"})
+
+      {:ok, _} =
+        Taxonomies.attach_ingredient(chicken_ing.id, nodes.chicken.id, %{source: "manual"})
+
+      assert [%{name: "Food", slug: "food", measurement_unit: "foods", amount: 2} = food] =
+               Taxonomies.build_tree(taxonomy.id)
+
+      assert [%{name: "Meat", amount: 2, children: meat_children}] = food.children
+
+      red_meat = Enum.find(meat_children, &(&1.slug == "red-meat"))
+      poultry = Enum.find(meat_children, &(&1.slug == "poultry"))
+
+      assert red_meat.amount == 1
+      assert [%{name: "Beef", amount: 1}, %{name: "Lamb", amount: 0}] = red_meat.children
+      assert poultry.amount == 1
+    end
+  end
+
+  describe "leaf helpers" do
+    test "list_leaf_nodes/1 and list_leaf_paths/1 return only childless nodes" do
+      taxonomy = taxonomy_fixture()
+      nodes = seed_meat_tree(taxonomy)
+
+      leaf_ids = Taxonomies.list_leaf_nodes(taxonomy.id) |> Enum.map(& &1.id) |> Enum.sort()
+      assert leaf_ids == Enum.sort([nodes.beef.id, nodes.lamb.id, nodes.chicken.id])
+
+      paths = Taxonomies.list_leaf_paths(taxonomy.id)
+      beef_path = Enum.find(paths, &(&1.slug == "beef"))
+      assert beef_path.path == "Food > Meat > Red Meat > Beef"
+    end
+  end
+
+  describe "attachment and review" do
+    test "attach_ingredient/3 is guarded by the unique constraint" do
+      taxonomy = taxonomy_fixture()
+      nodes = seed_meat_tree(taxonomy)
+      ingredient = FoodFixtures.ingredient_fixture()
+
+      assert {:ok, _} =
+               Taxonomies.attach_ingredient(ingredient.id, nodes.beef.id, %{source: "manual"})
+
+      assert {:error, changeset} =
+               Taxonomies.attach_ingredient(ingredient.id, nodes.beef.id, %{source: "manual"})
+
+      assert %{ingredient_id: ["has already been taken"]} = errors_on(changeset)
+    end
+
+    test "review_mapping/2 confirms or overrides a pending AI mapping" do
+      taxonomy = taxonomy_fixture()
+      nodes = seed_meat_tree(taxonomy)
+      ingredient = FoodFixtures.ingredient_fixture(%{name: "Lamb, shoulder, raw"})
+
+      {:ok, mapping} =
+        Taxonomies.attach_ingredient(ingredient.id, nodes.beef.id, %{
+          source: "ai",
+          confidence: 0.4
+        })
+
+      assert [pending] = Taxonomies.list_pending_review(taxonomy.id)
+      assert pending.id == mapping.id
+      assert Taxonomies.count_pending_review(taxonomy.id) == 1
+
+      {:ok, overridden} = Taxonomies.review_mapping(mapping.id, {:override, nodes.lamb.id})
+      assert overridden.taxonomy_node_id == nodes.lamb.id
+      assert overridden.source == "manual"
+      assert overridden.reviewed
+      assert is_nil(overridden.confidence)
+
+      assert Taxonomies.list_pending_review(taxonomy.id) == []
+
+      {:ok, second} =
+        Taxonomies.attach_ingredient(ingredient.id, nodes.chicken.id, %{
+          source: "ai",
+          confidence: 0.9
+        })
+
+      {:ok, confirmed} = Taxonomies.review_mapping(second, :confirm)
+      assert confirmed.reviewed
+      assert confirmed.taxonomy_node_id == nodes.chicken.id
+    end
+  end
+
+  defp ids(ingredients), do: ingredients |> Enum.map(& &1.id) |> Enum.sort()
+end

--- a/apps/mehungry/test/mehungry/food/taxonomy_seeder_test.exs
+++ b/apps/mehungry/test/mehungry/food/taxonomy_seeder_test.exs
@@ -1,0 +1,30 @@
+defmodule Mehungry.Food.TaxonomySeederTest do
+  use Mehungry.DataCase
+
+  alias Mehungry.Food.{Taxonomies, TaxonomySeeder}
+
+  test "seed/0 creates the bio-nutritional tree and is idempotent" do
+    taxonomy = TaxonomySeeder.seed()
+    assert taxonomy.slug == "bio-nutritional"
+
+    nodes = Taxonomies.list_nodes(taxonomy.id)
+    assert length(nodes) > 50
+
+    # The classifier's fallback leaf must exist and be a leaf.
+    fallback = Taxonomies.get_node_by_slug(taxonomy.id, "other-unclassified")
+    assert fallback
+    assert fallback.id in Enum.map(Taxonomies.list_leaf_nodes(taxonomy.id), & &1.id)
+
+    # Multi-level structure: Meat > Red Meat > Beef.
+    beef = Taxonomies.get_node_by_slug(taxonomy.id, "beef")
+    red_meat = Taxonomies.get_node_by_slug(taxonomy.id, "red-meat")
+    meat = Taxonomies.get_node_by_slug(taxonomy.id, "meat")
+    assert beef.parent_id == red_meat.id
+    assert red_meat.parent_id == meat.id
+    assert is_nil(meat.parent_id)
+
+    same_taxonomy = TaxonomySeeder.seed()
+    assert same_taxonomy.id == taxonomy.id
+    assert length(Taxonomies.list_nodes(taxonomy.id)) == length(nodes)
+  end
+end

--- a/apps/mehungry/test/mehungry/oban_workers/taxonomy_classification_worker_test.exs
+++ b/apps/mehungry/test/mehungry/oban_workers/taxonomy_classification_worker_test.exs
@@ -1,0 +1,99 @@
+defmodule Mehungry.ObanWorkers.TaxonomyClassificationWorkerTest do
+  use Mehungry.DataCase
+  use Oban.Testing, repo: Mehungry.Repo
+
+  import Mehungry.FoodFixtures
+
+  alias Mehungry.Food.{IngredientTaxonomyNode, Taxonomies}
+  alias Mehungry.ObanWorkers.TaxonomyClassificationWorker
+  alias Mehungry.Repo
+
+  setup do
+    on_exit(fn -> Application.delete_env(:mehungry, :taxonomy_classifier_stub) end)
+
+    {:ok, taxonomy} = Taxonomies.create_taxonomy(%{name: "Bio", slug: "bio-nutritional"})
+    {:ok, meat} = Taxonomies.create_node(%{name: "Meat", slug: "meat", taxonomy_id: taxonomy.id})
+
+    {:ok, beef} =
+      Taxonomies.create_node(%{
+        name: "Beef",
+        slug: "beef",
+        taxonomy_id: taxonomy.id,
+        parent_id: meat.id
+      })
+
+    {:ok, other} =
+      Taxonomies.create_node(%{
+        name: "Other / Unclassified",
+        slug: "other-unclassified",
+        taxonomy_id: taxonomy.id
+      })
+
+    %{taxonomy: taxonomy, beef: beef, other: other}
+  end
+
+  test "writes AI mappings and re-enqueues while work remains", ctx do
+    ingredient = ingredient_fixture(%{name: "Beef, ground, raw"})
+    test_pid = self()
+
+    Application.put_env(:mehungry, :taxonomy_classifier_stub, fn ingredients, leaves ->
+      send(test_pid, {:classified, ingredients, leaves})
+
+      {:ok,
+       Map.new(ingredients, fn %{id: id} -> {id, %{slug: "beef", confidence: 0.9}} end)}
+    end)
+
+    assert :ok = perform_job(TaxonomyClassificationWorker, %{"taxonomy_id" => ctx.taxonomy.id})
+
+    assert_received {:classified, ingredients, leaves}
+    assert Enum.any?(ingredients, &(&1.id == ingredient.id))
+    leaf_slugs = Enum.map(leaves, & &1.slug) |> Enum.sort()
+    assert leaf_slugs == ["beef", "other-unclassified"]
+
+    mapping = Repo.get_by!(IngredientTaxonomyNode, ingredient_id: ingredient.id)
+    assert mapping.taxonomy_node_id == ctx.beef.id
+    assert mapping.source == "ai"
+    assert mapping.confidence == 0.9
+    refute mapping.reviewed
+
+    assert_enqueued(
+      worker: TaxonomyClassificationWorker,
+      args: %{taxonomy_id: ctx.taxonomy.id}
+    )
+  end
+
+  test "completes without re-enqueue when everything is classified", ctx do
+    ingredient = ingredient_fixture()
+    {:ok, _} = Taxonomies.attach_ingredient(ingredient.id, ctx.beef.id, %{source: "manual"})
+
+    Application.put_env(:mehungry, :taxonomy_classifier_stub, fn _ingredients, _leaves ->
+      flunk("classifier should not be called when nothing is unclassified")
+    end)
+
+    assert :ok = perform_job(TaxonomyClassificationWorker, %{"taxonomy_id" => ctx.taxonomy.id})
+    refute_enqueued(worker: TaxonomyClassificationWorker)
+  end
+
+  test "stops the chain when a batch yields no usable assignments", ctx do
+    ingredient_fixture(%{name: "Mystery substance"})
+
+    Application.put_env(:mehungry, :taxonomy_classifier_stub, fn _ingredients, _leaves ->
+      {:ok, %{}}
+    end)
+
+    assert :ok = perform_job(TaxonomyClassificationWorker, %{"taxonomy_id" => ctx.taxonomy.id})
+    refute_enqueued(worker: TaxonomyClassificationWorker)
+    assert Repo.aggregate(IngredientTaxonomyNode, :count) == 0
+  end
+
+  test "returns an error for Oban retries when the classifier fails", ctx do
+    ingredient_fixture()
+
+    Application.put_env(:mehungry, :taxonomy_classifier_stub, fn _ingredients, _leaves ->
+      {:error, :api_down}
+    end)
+
+    assert {:error, :api_down} =
+             perform_job(TaxonomyClassificationWorker, %{"taxonomy_id" => ctx.taxonomy.id})
+  end
+end

--- a/apps/mehungry/test/support/taxonomy_classifier_stub.ex
+++ b/apps/mehungry/test/support/taxonomy_classifier_stub.ex
@@ -1,0 +1,24 @@
+defmodule Mehungry.AI.TaxonomyClassifierStub do
+  @moduledoc """
+  Test stand-in for `Mehungry.AI.TaxonomyClassifier` (wired up via the
+  `:taxonomy_classifier` config key in `config/test.exs`).
+
+  Tests control the result and observe calls through app config:
+
+      Application.put_env(:mehungry, :taxonomy_classifier_stub, fn ingredients, _leaves ->
+        send(test_pid, {:classify, ingredients})
+        {:ok, %{}}
+      end)
+      on_exit(fn -> Application.delete_env(:mehungry, :taxonomy_classifier_stub) end)
+  """
+
+  @behaviour Mehungry.AI.TaxonomyClassifierBehaviour
+
+  @impl true
+  def classify(ingredients, leaves) do
+    case Application.get_env(:mehungry, :taxonomy_classifier_stub) do
+      nil -> {:ok, %{}}
+      fun -> fun.(ingredients, leaves)
+    end
+  end
+end

--- a/apps/mehungry_web/lib/mehungry_web/live/professional_live/taxonomy_review.ex
+++ b/apps/mehungry_web/lib/mehungry_web/live/professional_live/taxonomy_review.ex
@@ -1,0 +1,181 @@
+defmodule MehungryWeb.ProfessionalLive.TaxonomyReview do
+  use MehungryWeb, :live_view
+
+  alias Mehungry.Food.Taxonomies
+  alias MehungryWeb.AccordionComponent
+
+  @taxonomy_slug "bio-nutritional"
+  @page_size 50
+
+  @impl true
+  def mount(_params, _session, socket) do
+    taxonomy = Taxonomies.get_taxonomy_by_slug(@taxonomy_slug)
+
+    socket =
+      socket
+      |> assign(:page_title, "Ingredient Taxonomy Review")
+      |> assign(:taxonomy, taxonomy)
+      |> assign(:limit, @page_size)
+      |> load_taxonomy_data()
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def render(%{taxonomy: nil} = assigns) do
+    ~H"""
+    <div class="text-slate-300">
+      <h1 class="text-xl font-bold text-white mb-2">Ingredient Taxonomy Review</h1>
+      <p>
+        No taxonomy found. Seed it first with <code class="text-amber-400">mix taxonomy.seed</code>.
+      </p>
+    </div>
+    """
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div>
+      <div class="flex items-center justify-between mb-4">
+        <div>
+          <h1 class="text-xl font-bold text-white">Ingredient Taxonomy Review</h1>
+          <p class="text-sm text-slate-400 mt-0.5">
+            {@taxonomy.name} — confirm or override AI leaf assignments
+          </p>
+        </div>
+        <div class="text-sm text-slate-400">
+          <span class="text-amber-400 font-semibold">{@pending_count}</span> pending review
+        </div>
+      </div>
+
+      <div class="mb-6 rounded-xl border border-slate-700/60 overflow-hidden">
+        <div class="px-4 py-2 bg-slate-800/60 text-sm font-medium text-slate-300">
+          Taxonomy tree (rolled-up ingredient counts)
+        </div>
+        <AccordionComponent.accordion items={@tree} accordion_id="taxonomy-tree" />
+      </div>
+
+      <div class="rounded-xl border border-slate-700/60 overflow-x-auto">
+        <table class="w-full text-sm text-left">
+          <thead class="bg-slate-800/60 text-slate-300">
+            <tr>
+              <th class="px-4 py-2 font-medium">Ingredient</th>
+              <th class="px-4 py-2 font-medium">USDA category</th>
+              <th class="px-4 py-2 font-medium">Assigned node</th>
+              <th class="px-4 py-2 font-medium">Confidence</th>
+              <th class="px-4 py-2 font-medium">Source</th>
+              <th class="px-4 py-2 font-medium">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr :if={@pending == []}>
+              <td colspan="6" class="px-4 py-6 text-center text-slate-400">
+                Nothing pending review.
+              </td>
+            </tr>
+            <tr
+              :for={mapping <- @pending}
+              id={"mapping-#{mapping.id}"}
+              class="border-t border-slate-700/40 text-slate-200"
+            >
+              <td class="px-4 py-2">{mapping.ingredient.name}</td>
+              <td class="px-4 py-2 text-slate-400">
+                {mapping.ingredient.category && mapping.ingredient.category.name}
+              </td>
+              <td class="px-4 py-2">{node_path(mapping.taxonomy_node, @leaf_paths)}</td>
+              <td class="px-4 py-2">{format_confidence(mapping.confidence)}</td>
+              <td class="px-4 py-2 text-slate-400">{mapping.source}</td>
+              <td class="px-4 py-2">
+                <div class="flex items-center gap-2">
+                  <button
+                    phx-click="confirm"
+                    phx-value-id={mapping.id}
+                    class="px-2.5 py-1 rounded-lg bg-emerald-500/20 hover:bg-emerald-500/30 text-emerald-400 border border-emerald-500/30 text-xs font-medium transition-colors"
+                  >
+                    Confirm
+                  </button>
+                  <form phx-submit="override" class="flex items-center gap-1">
+                    <input type="hidden" name="id" value={mapping.id} />
+                    <select
+                      name="node_id"
+                      class="bg-slate-800 border border-slate-700/60 rounded-lg text-slate-200 text-xs px-2 py-1 focus:border-amber-500/50 focus:outline-none"
+                    >
+                      <option
+                        :for={leaf <- @leaf_paths}
+                        value={leaf.id}
+                        selected={leaf.id == mapping.taxonomy_node_id}
+                      >
+                        {leaf.path}
+                      </option>
+                    </select>
+                    <button
+                      type="submit"
+                      class="px-2.5 py-1 rounded-lg bg-amber-500/20 hover:bg-amber-500/30 text-amber-400 border border-amber-500/30 text-xs font-medium transition-colors"
+                    >
+                      Override
+                    </button>
+                  </form>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div :if={@pending_count > length(@pending)} class="mt-4 text-center">
+        <button
+          phx-click="load-more"
+          class="px-4 py-2 rounded-lg text-slate-300 hover:text-white hover:bg-slate-800 border border-slate-700/60 text-sm transition-colors"
+        >
+          Load more
+        </button>
+      </div>
+    </div>
+    """
+  end
+
+  @impl true
+  def handle_event("confirm", %{"id" => id}, socket) do
+    {:ok, _} = Taxonomies.review_mapping(String.to_integer(id), :confirm)
+
+    {:noreply, load_taxonomy_data(socket)}
+  end
+
+  @impl true
+  def handle_event("override", %{"id" => id, "node_id" => node_id}, socket) do
+    {:ok, _} =
+      Taxonomies.review_mapping(
+        String.to_integer(id),
+        {:override, String.to_integer(node_id)}
+      )
+
+    {:noreply, load_taxonomy_data(socket)}
+  end
+
+  @impl true
+  def handle_event("load-more", _params, socket) do
+    socket = assign(socket, :limit, socket.assigns.limit + @page_size)
+
+    {:noreply, load_taxonomy_data(socket)}
+  end
+
+  defp load_taxonomy_data(%{assigns: %{taxonomy: nil}} = socket), do: socket
+
+  defp load_taxonomy_data(%{assigns: %{taxonomy: taxonomy}} = socket) do
+    socket
+    |> assign(:tree, Taxonomies.build_tree(taxonomy.id))
+    |> assign(:pending, Taxonomies.list_pending_review(taxonomy.id, limit: socket.assigns.limit))
+    |> assign(:pending_count, Taxonomies.count_pending_review(taxonomy.id))
+    |> assign(:leaf_paths, Taxonomies.list_leaf_paths(taxonomy.id))
+  end
+
+  defp node_path(node, leaf_paths) do
+    case Enum.find(leaf_paths, &(&1.id == node.id)) do
+      nil -> node.name
+      leaf -> leaf.path
+    end
+  end
+
+  defp format_confidence(nil), do: "—"
+  defp format_confidence(confidence), do: "#{round(confidence * 100)}%"
+end

--- a/apps/mehungry_web/lib/mehungry_web/router.ex
+++ b/apps/mehungry_web/lib/mehungry_web/router.ex
@@ -73,6 +73,8 @@ defmodule MehungryWeb.Router do
       live "/ingredients/new", ProfessionalLive.IngredientsCreate, :create
       live "/ingredients/:id/show", Professional.IngredientLive.Show, :show
 
+      live "/taxonomy/review", ProfessionalLive.TaxonomyReview, :index
+
       live "/languages", Professional.LanguageLive.Index, :index
       live "/languages/new", Professional.LanguageLive.Index, :new
       live "/languages/:id/edit", Professional.LanguageLive.Index, :edit

--- a/apps/mehungry_web/test/mehungry_web/live/taxonomy_review_test.exs
+++ b/apps/mehungry_web/test/mehungry_web/live/taxonomy_review_test.exs
@@ -1,0 +1,122 @@
+defmodule MehungryWeb.TaxonomyReviewTest do
+  use MehungryWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Mehungry.FoodFixtures
+
+  alias Mehungry.Food.Taxonomies
+
+  setup %{conn: conn} do
+    admin =
+      Mehungry.AccountsFixtures.user_fixture(%{
+        email: Application.get_env(:mehungry, :admin_email)
+      })
+
+    conn = log_in_user(conn, admin)
+
+    {:ok, taxonomy} =
+      Taxonomies.create_taxonomy(%{name: "Biological / Nutritional", slug: "bio-nutritional"})
+
+    {:ok, meat} = Taxonomies.create_node(%{name: "Meat", slug: "meat", taxonomy_id: taxonomy.id})
+
+    {:ok, red_meat} =
+      Taxonomies.create_node(%{
+        name: "Red Meat",
+        slug: "red-meat",
+        taxonomy_id: taxonomy.id,
+        parent_id: meat.id
+      })
+
+    {:ok, beef} =
+      Taxonomies.create_node(%{
+        name: "Beef",
+        slug: "beef",
+        taxonomy_id: taxonomy.id,
+        parent_id: red_meat.id
+      })
+
+    {:ok, lamb} =
+      Taxonomies.create_node(%{
+        name: "Lamb",
+        slug: "lamb",
+        taxonomy_id: taxonomy.id,
+        parent_id: red_meat.id
+      })
+
+    %{conn: conn, taxonomy: taxonomy, beef: beef, lamb: lamb}
+  end
+
+  test "renders the taxonomy tree through the accordion", %{conn: conn} do
+    {:ok, _view, html} = live(conn, ~p"/professional/taxonomy/review")
+
+    assert html =~ "Ingredient Taxonomy Review"
+    assert html =~ "Meat"
+    assert html =~ "Red Meat"
+    assert html =~ "Beef"
+    assert html =~ "Nothing pending review."
+  end
+
+  test "confirming a pending mapping marks it reviewed", %{
+    conn: conn,
+    taxonomy: taxonomy,
+    beef: beef
+  } do
+    ingredient = ingredient_fixture(%{name: "Beef, ground, raw"})
+
+    {:ok, mapping} =
+      Taxonomies.attach_ingredient(ingredient.id, beef.id, %{source: "ai", confidence: 0.9})
+
+    {:ok, view, html} = live(conn, ~p"/professional/taxonomy/review")
+    assert html =~ "Beef, ground, raw"
+    assert html =~ "90%"
+
+    html =
+      view
+      |> element("#mapping-#{mapping.id} button", "Confirm")
+      |> render_click()
+
+    assert html =~ "Nothing pending review."
+    assert Taxonomies.count_pending_review(taxonomy.id) == 0
+
+    reloaded = Mehungry.Repo.get!(Mehungry.Food.IngredientTaxonomyNode, mapping.id)
+    assert reloaded.reviewed
+    assert reloaded.source == "ai"
+  end
+
+  test "overriding a pending mapping moves it to the chosen leaf", %{
+    conn: conn,
+    taxonomy: taxonomy,
+    beef: beef,
+    lamb: lamb
+  } do
+    ingredient = ingredient_fixture(%{name: "Lamb, shoulder, raw"})
+
+    {:ok, mapping} =
+      Taxonomies.attach_ingredient(ingredient.id, beef.id, %{source: "ai", confidence: 0.4})
+
+    {:ok, view, _html} = live(conn, ~p"/professional/taxonomy/review")
+
+    html =
+      view
+      |> element("#mapping-#{mapping.id} form")
+      |> render_submit(%{"id" => to_string(mapping.id), "node_id" => to_string(lamb.id)})
+
+    assert html =~ "Nothing pending review."
+    assert Taxonomies.count_pending_review(taxonomy.id) == 0
+
+    reloaded = Mehungry.Repo.get!(Mehungry.Food.IngredientTaxonomyNode, mapping.id)
+    assert reloaded.taxonomy_node_id == lamb.id
+    assert reloaded.source == "manual"
+    assert reloaded.reviewed
+    assert is_nil(reloaded.confidence)
+  end
+
+  test "a non-admin user is redirected away", %{taxonomy: _taxonomy} do
+    conn = Phoenix.ConnTest.build_conn()
+    user = Mehungry.AccountsFixtures.user_fixture()
+    conn = log_in_user(conn, user)
+
+    assert {:error, {:redirect, %{to: "/home"}}} =
+             live(conn, ~p"/professional/taxonomy/review")
+  end
+end

--- a/config/test.exs
+++ b/config/test.exs
@@ -32,6 +32,7 @@ config :mehungry, :off_client, Mehungry.FoodData.OpenFoodFacts.ClientStub
 # Instagram Graph API client + social media publisher are stubbed in tests
 config :mehungry, :instagram_client, Mehungry.Social.Instagram.ClientStub
 config :mehungry, :social_media_publisher, Mehungry.Social.PublisherStub
+config :mehungry, :taxonomy_classifier, Mehungry.AI.TaxonomyClassifierStub
 
 # Chrome
 # default


### PR DESCRIPTION
Builds the foundation for meaningful multi-level hierarchies over ingredients — e.g. `Food → Meat → Red Meat → Beef → {USDA beef rows}` — with room for multiple independent taxonomies over the same ingredient pool. Downstream food-profile consumption is out of scope; this delivers the schema, one seeded taxonomy, AI classification, and an admin review UI.

## Schema (`20260723120000_create_taxonomies.exs`)

- `taxonomies` — independent trees (slug-unique).
- `taxonomy_nodes` — adjacency list via `parent_id`; slugs unique **per taxonomy** (not per parent) because PG14 treats NULL `parent_id` as distinct in unique indexes.
- `ingredient_taxonomy_nodes` — ingredient↔node join with `source` (`usda_seed|ai|manual`), `confidence`, `reviewed`. No per-taxonomy exclusivity: multi-membership stays possible by design.
- `categories.usda_code` — the USDA food parser now keeps `foodCategory`/`wweiaFoodCategory` codes instead of discarding them.

## Context layer

`Mehungry.Food.Taxonomies` (with matching `defdelegate`s on the `Mehungry.Food` facade): taxonomy/node CRUD, `build_tree/1` (nested maps with rolled-up ingredient counts, in the exact shape `AccordionComponent` consumes), `subtree_node_ids/1` + `list_ingredients_under_node/1` via a recursive CTE, attach/detach, and review helpers.

## Population pipeline

1. `Mehungry.Food.TaxonomySeeder` (+ `mix taxonomy.seed`, hooked into `seeds.exs`) idempotently creates the curated **Biological / Nutritional** tree (~80 nodes), including the load-bearing *Other / Unclassified* fallback leaf.
2. `Mehungry.AI.TaxonomyClassifier` — single-shot JSON prompt over the existing `AI.Client`, mirroring `AI.IngredientTranslator`; returns leaf slug + confidence per ingredient, invalid slugs dropped.
3. `TaxonomyClassificationWorker` (`ai_agents` queue, `mix taxonomy.classify`) batches 40 unclassified ingredients at a time and re-enqueues itself until done; a zero-insert batch stops the chain to avoid retry loops. The classifier is resolved through a `:taxonomy_classifier` config seam (same pattern as `:social_media_publisher`) and stubbed in tests.

## Admin review

`/professional/taxonomy/review` (admin live_session): renders the tree through the existing `AccordionComponent` and lists unreviewed mappings lowest-confidence first with per-row **Confirm** / **Override** (leaf-path select) actions.

## Tests

- `taxonomies_test.exs` — recursive CTE across a 4-level tree, `build_tree` shape + rolled-up counts, slug/attachment constraints (incl. the duplicate-root PG14 case), review confirm/override.
- `taxonomy_seeder_test.exs` — idempotency, fallback leaf, Meat > Red Meat > Beef structure.
- `taxonomy_classification_worker_test.exs` — mappings written, re-enqueue while work remains, halt on empty/zero-insert batches, error propagation for Oban retries.
- `taxonomy_review_test.exs` — accordion render, confirm/override round-trips, non-admin redirect.

Note: this environment couldn't reach `repo.hex.pm`, so tests were not run locally — all files are syntax-checked and CI is the verification gate for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vu1nJj1Qjujn35MqNuWTMA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vu1nJj1Qjujn35MqNuWTMA)_