### PR TITLE
Fix FireLens config: use null output for mehungry_app container

### DIFF
--- a/task-definition.json
+++ b/task-definition.json
@@ -183,12 +183,7 @@
             "logConfiguration": {
                 "logDriver": "awsfirelens",
                 "options": {
-                    "awslogs-group": "/ecs/mehungry_app_deployment",
-                    "mode": "non-blocking",
-                    "awslogs-create-group": "true",
-                    "max-buffer-size": "25m",
-                    "awslogs-region": "eu-central-1",
-                    "awslogs-stream-prefix": "ecs"
+                    "Name": "null"
                 },
                 "secretOptions": []
             },


### PR DESCRIPTION
The mehungry_app container uses the awsfirelens log driver, but its logConfiguration.options were still awslogs-style keys with no Name. FireLens converts these options into a Fluent Bit [OUTPUT] section that requires a Name key, so task launch failed with "missing output key Name". Actual routing is handled by fluent-bit/extra.conf (Match *), so point the generated output at the null plugin.