### PR TITLE
Drop awslogs-create-group for log_router; group pre-created

### DIFF
--- a/task-definition.json
+++ b/task-definition.json
@@ -36,7 +36,6 @@
              "options": {
               "awslogs-group": "/ecs/mehungry_firelens",
               "awslogs-region": "eu-central-1",
-              "awslogs-create-group": "true",
               "awslogs-stream-prefix": "firelens",
               "mode": "non-blocking",
               "max-buffer-size": "25m"


### PR DESCRIPTION
ecsTaskExecutionRole has no logs:CreateLogGroup permission (the existing /ecs/mehungry_app_deployment group predates this and was never created by the role). With awslogs-create-group:true the driver attempts CreateLogGroup for the new /ecs/mehungry_firelens group and fails with AccessDenied. The group is now pre-created out of band, so the driver only needs CreateLogStream/PutLogEvents, which the role already has.